### PR TITLE
Set redirect status to 307

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function redirectToHTTPS (ignoreHosts = [], ignoreRoutes = []) {
 
     if (isNotSecure && !searchIgnore(req.get('host'), ignoreHosts) &&
       !searchIgnore(req.path, ignoreRoutes)) {
-      return res.redirect('https://' + req.get('host') + req.url)
+      return res.redirect(407,'https://' + req.get('host') + req.url)
     }
 
     next()


### PR DESCRIPTION
 "The difference between 307 and 302 is that 307 guarantees that the method and the body will not be changed when the redirected request is made. With 302, some old clients were incorrectly changing the method to GET: the behavior with non-GET methods and 302 is then unpredictable on the Web, whereas the 307 one is".(HTTP DOC)